### PR TITLE
Fix sql server queries formatting

### DIFF
--- a/ThinkingHome.Migrator.Providers.SqlServer/SqlServerTransformationProvider.cs
+++ b/ThinkingHome.Migrator.Providers.SqlServer/SqlServerTransformationProvider.cs
@@ -197,13 +197,13 @@ namespace ThinkingHome.Migrator.Providers.SqlServer
 
             string sql = FormatSql(
                 "SELECT TOP 1 {0:NAME} FROM {1:NAME} " +
-                "WHERE {2:NAME} = object_id('{3:NAME}') " +
-                "AND {4:NAME} = object_id('{5:NAME}') " +
+                "WHERE {2:NAME} = object_id('{3}') " +
+                "AND {4:NAME} = object_id('{5}') " +
                 "AND {6:NAME} IN ('D', 'F', 'PK', 'UQ')" +
                 "UNION ALL " +
                 "SELECT TOP 1 {0:NAME} FROM {7:NAME} " +
-                "WHERE {2:NAME} = OBJECT_ID(N'{3:NAME}') AND " +
-                "{4:NAME} = OBJECT_ID(N'{5:NAME}')",
+                "WHERE {2:NAME} = OBJECT_ID(N'{3}') AND " +
+                "{4:NAME} = OBJECT_ID(N'{5}')",
                 "name", "objects".WithSchema("sys"), "parent_object_id", table,
                 "object_id", fullConstraintName, "type", "check_constraints".WithSchema("sys"));
 
@@ -281,7 +281,7 @@ namespace ThinkingHome.Migrator.Providers.SqlServer
                 "dobj", "object_id", "col", "default_object_id", "type"));
 
             sqlBuilder.Append(FormatSql(
-                "WHERE {0:NAME}.{1:NAME} = object_id(N'{2:NAME}') AND {0:NAME}.{3:NAME} = '{4:NAME}'",
+                "WHERE {0:NAME}.{1:NAME} = object_id(N'{2}') AND {0:NAME}.{3:NAME} = '{4}'",
                 "col", "object_id", table, "name", column));
 
             return sqlBuilder.ToString();

--- a/ThinkingHome.Migrator.Providers.SqlServer/SqlServerTransformationProvider.cs
+++ b/ThinkingHome.Migrator.Providers.SqlServer/SqlServerTransformationProvider.cs
@@ -70,7 +70,7 @@ namespace ThinkingHome.Migrator.Providers.SqlServer
             sqlBuilder.Append(FormatSql("INNER JOIN {0:NAME} {1:NAME} ", "objects".WithSchema("sys"), "dobj"));
             sqlBuilder.Append(FormatSql("ON {0:NAME}.{1:NAME} = {2:NAME}.{3:NAME} AND {0:NAME}.{4:NAME} = 'D' ",
                 "dobj", "object_id", "col", "default_object_id", "type"));
-            sqlBuilder.Append(FormatSql("WHERE {0:NAME}.{1:NAME} = object_id(N'{2}') AND {0:NAME}.{3:NAME} = '{4}'",
+            sqlBuilder.Append(FormatSql("WHERE {0:NAME}.{1:NAME} = object_id(N'{2:NAME}') AND {0:NAME}.{3:NAME} = '{4}'",
                 "col", "object_id", table, "name", column));
 
             using (var reader = ExecuteReader(sqlBuilder.ToString()))
@@ -197,13 +197,13 @@ namespace ThinkingHome.Migrator.Providers.SqlServer
 
             string sql = FormatSql(
                 "SELECT TOP 1 {0:NAME} FROM {1:NAME} " +
-                "WHERE {2:NAME} = object_id('{3}') " +
-                "AND {4:NAME} = object_id('{5}') " +
+                "WHERE {2:NAME} = object_id('{3:NAME}') " +
+                "AND {4:NAME} = object_id('{5:NAME}') " +
                 "AND {6:NAME} IN ('D', 'F', 'PK', 'UQ')" +
                 "UNION ALL " +
                 "SELECT TOP 1 {0:NAME} FROM {7:NAME} " +
-                "WHERE {2:NAME} = OBJECT_ID(N'{3}') AND " +
-                "{4:NAME} = OBJECT_ID(N'{5}')",
+                "WHERE {2:NAME} = object_id(N'{3:NAME}') AND " +
+                "{4:NAME} = object_id(N'{5:NAME}')",
                 "name", "objects".WithSchema("sys"), "parent_object_id", table,
                 "object_id", fullConstraintName, "type", "check_constraints".WithSchema("sys"));
 
@@ -281,7 +281,7 @@ namespace ThinkingHome.Migrator.Providers.SqlServer
                 "dobj", "object_id", "col", "default_object_id", "type"));
 
             sqlBuilder.Append(FormatSql(
-                "WHERE {0:NAME}.{1:NAME} = object_id(N'{2}') AND {0:NAME}.{3:NAME} = '{4}'",
+                "WHERE {0:NAME}.{1:NAME} = object_id(N'{2:NAME}') AND {0:NAME}.{3:NAME} = '{4}'",
                 "col", "object_id", table, "name", column));
 
             return sqlBuilder.ToString();


### PR DESCRIPTION
Разбирался, почему не получается накатить миграцию. Обнаружил, что некоторые запросы форматируются в `'[SomeName]'`, хотя по факту должно быть или `[SomeName]` или `'SomeName'`. Поправил запросы для Sql Server.
По логике мы можем использовать или `{0:Name}` или `'{0}'` форматирование
